### PR TITLE
xargs, default.cfg aligned, fixed CI

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -30,4 +30,4 @@ jobs:
           prerelease: false
           automatic_release_tag: prod/v0.x
           files: |
-            light-proxy.tar.gz
+            ../light-proxy.tar.gz

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,4 +1,4 @@
-name: Production
+name: Staging
 
 on: 
   push:
@@ -8,17 +8,20 @@ on:
     types: [ assigned, opened, synchronize, reopened ]
 
 jobs:
-  default:
+  production-build:
     runs-on: ubuntu-latest
     steps:
-    
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Test full-install
+        run: |
+          sudo ./full-install.sh
 
       - name: Create release
         run: |
           cd ..
-          sudo tar -czvf $GITHUB_WORKSPACE.tar.gz $GITHUB_WORKSPACE/
+          sudo tar -czvf light-proxy.tar.gz light-proxy/
 
       - name: Release latest
         uses: "marvinpinto/action-automatic-releases@latest"
@@ -27,4 +30,4 @@ jobs:
           prerelease: false
           automatic_release_tag: prod/v0.x
           files: |
-            $GITHUB_WORKSPACE.tar.gz
+            light-proxy.tar.gz

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -23,7 +23,6 @@ jobs:
         run: |
           cd ..
           sudo tar -czvf light-proxy.tar.gz light-proxy/
-
       - name: Release latest
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
@@ -31,4 +30,4 @@ jobs:
           prerelease: true
           automatic_release_tag: staged/v0.x
           files: |
-            light-proxy.tar.gz
+            ../light-proxy.tar.gz

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -8,7 +8,7 @@ on:
     types: [ assigned, opened, synchronize, reopened ]
 
 jobs:
-  default:
+  staging-build:
     runs-on: ubuntu-latest
     steps:
     
@@ -22,7 +22,7 @@ jobs:
       - name: Create release
         run: |
           cd ..
-          sudo tar -czvf $GITHUB_WORKSPACE.tar.gz $GITHUB_WORKSPACE/
+          sudo tar -czvf light-proxy.tar.gz light-proxy/
 
       - name: Release latest
         uses: "marvinpinto/action-automatic-releases@latest"
@@ -31,4 +31,4 @@ jobs:
           prerelease: true
           automatic_release_tag: staged/v0.x
           files: |
-            $GITHUB_WORKSPACE.tar.gz
+            light-proxy.tar.gz

--- a/README.md
+++ b/README.md
@@ -5,24 +5,13 @@
 
 &emsp;&emsp;&emsp;&emsp;Creates `edit-proxy`, a userspace command for quickly changing your proxy as your working.
 
-
-## Installation
-You should install at-most one reverse proxy per userspace
+## Install
 ```
 curl -sL https://github.com/light-river/light-proxy/archive/refs/tags/prod/v0.x.tar.gz | tar zx && cd light-proxy-prod-v0.x && ./full-install.sh
-```
 
-## Making changes to your proxy
-The `edit-proxy` command is now available throuhgout your users namespace.
-Changes made this way will automatically restart your Apache2 daemon
+```
+## Edit the proxy
 ```
 edit-proxy
 ```
 - - -
-
-## Host Requirements
-
-- Debian/Ubuntu host with a public `ipv4` address.
-- Domain name with an `A record` pointing at your public `ipv4` address. 
-- Application that you want to proxy requests to. (This could a docker container, fileserver, or entierly other host.)
-

--- a/full-install.sh
+++ b/full-install.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 
+# Args
+# 1) domain name you're signing | default: proxy.localhost
+# 2) output parent folder for certs | default: /.light-certs/proxy.localhost/*
+host_name=${1:-proxy.localhost}
+cert_root_path="${2:-"/.light-certs/"}$host_name"
+echo -e "configured with \n\t host_name: $host_name \n\t cert_path: $cert_root_path"
+
 # Install light-ca
 curl -sL https://github.com/light-river/light-ca/releases/download/latest/light-ca.tar.gz | tar zx && sudo mv ./light-ca /usr/bin/light-ca
-light-ca --domains 'proxy.localhost' 
-light-ca --domains '*.proxy.localhost'
+sudo light-ca --domains "$host_name"
+sudo light-ca --domains "*.$host_name"
+
+# Move certs
+sudo mkdir -p cert_root_path
+sudo mv "./$host_name/*" "$cert_root_path"
+echo "certs installed at $cert_root_path"
 
 # Install Apache2
 sudo apt-get update
@@ -13,7 +25,7 @@ sudo apt-get install apache2
 sudo systemctl stop apache2.service
 sudo systemctl start apache2.service
 sudo systemctl enable apache2.service
-sudo systemctl stop apache2.service
+sudo systemctl restart apache2.service
 
 # Install apache proxy modules
 sudo a2enmod ssl
@@ -22,7 +34,7 @@ sudo a2enmod proxy_http
 sudo a2enmod proxy_balancer
 sudo a2enmod proxy_wstunnel
 sudo a2enmod proxy_connect
-sudo systemctl restart apache2
+sudo systemctl restart apache2.service
 
 # Copy over template configuration to Apache
 sudo cp ./template-configs/default.cfg /etc/apache2/sites-available/Apache2Proxy.conf

--- a/full-install.sh
+++ b/full-install.sh
@@ -13,7 +13,7 @@ sudo light-ca --domains "$host_name"
 sudo light-ca --domains "*.$host_name"
 
 # Move certs
-sudo mkdir -p cert_root_path
+sudo mkdir -p $cert_root_path
 sudo mv "./$host_name/*" "$cert_root_path"
 echo "certs installed at $cert_root_path"
 

--- a/full-install.sh
+++ b/full-install.sh
@@ -14,7 +14,7 @@ sudo light-ca --domains "*.$host_name"
 
 # Move certs
 sudo mkdir -p $cert_root_path
-sudo mv "./$host_name/*" "$cert_root_path"
+sudo mv "$host_name/*" "$cert_root_path"
 echo "certs installed at $cert_root_path"
 
 # Install Apache2

--- a/links/edit-proxy
+++ b/links/edit-proxy
@@ -1,3 +1,3 @@
 #!/bin/bash
-sudo nano /etc/apache2/sites-available/Apache2Proxy.conf
+sudo vim /etc/apache2/sites-available/Apache2Proxy.conf
 sudo systemctl restart apache2.service

--- a/template-configs/default.cfg
+++ b/template-configs/default.cfg
@@ -1,7 +1,5 @@
-# Required: 
-#     1. Replace all example.com's with your domain name
-#     2. Adjust ProxyPass & ProxyPassReverse to point at the servers you're proxying requests for
-#           1a. By default, we're proxying all traffic to example.com -> 0.0.0.0:8443
+# You can adjust ProxyPass & ProxyPassReverse to point at the servers you're proxying requests for
+#   1a. By default, we're proxying all traffic to example.com -> 0.0.0.0:8443
 
 # Optional: 
 #     1. Replace the *'s with specific ipv4 addresses
@@ -36,7 +34,6 @@
         # You can define multiple rules for routing traffic of various protocols to various servers
         ProxyPass / http://0.0.0.0:8443/
         ProxyPassReverse / http://0.0.0.0:8443/
-        # ^^ Change here
          
         <Location />
           Order allow,deny

--- a/template-configs/default.cfg
+++ b/template-configs/default.cfg
@@ -7,7 +7,7 @@
 
 # We force all redirect all traffic from port 80 to secure port 443  
 <VirtualHost *:80>
-   ServerName http://0.0.0.0/
+   ServerName http://proxy.localhost/
    Redirect / https://proxy.localhost/
 </VirtualHost>
    
@@ -15,7 +15,7 @@
         # This disables Apache operating as a forward-proxy
         # We want to use it as a reverse-proxy, thus it's turned off
         # reference: https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxyrequests
-       ServerName proxy.localhost
+        ServerName proxy.localhost
         ProxyRequests Off
         <Proxy *>
           Order deny,allow

--- a/template-configs/default.cfg
+++ b/template-configs/default.cfg
@@ -7,15 +7,15 @@
 
 # We force all redirect all traffic from port 80 to secure port 443  
 <VirtualHost *:80>
-   ServerName http://example.com
-   Redirect / https://example.com
+   ServerName http://0.0.0.0/
+   Redirect / https://proxy.localhost/
 </VirtualHost>
    
 <VirtualHost *:443> 
         # This disables Apache operating as a forward-proxy
         # We want to use it as a reverse-proxy, thus it's turned off
         # reference: https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxyrequests
-       ServerName example.com
+       ServerName proxy.localhost
         ProxyRequests Off
         <Proxy *>
           Order deny,allow
@@ -27,8 +27,8 @@
         SSLEngine on
         SSLProxyEngine On
         # NOTE: Make sure you change the "example.com" in the filepath
-        SSLCertificateFile /etc/letsencrypt/live/example.com/cert.pem
-        SSLCertificateKeyFile /etc/letsencrypt/live/example.com/privkey.pem
+        SSLCertificateFile /.light-certs/proxy.localhost/cert.pem
+        SSLCertificateKeyFile /.light-certs/proxy.localhost/key.pem
         
         # The server on the we're proxying requests to
         # You can define multiple rules for routing traffic of various protocols to various servers


### PR DESCRIPTION
Closes #4 

<img align="left" src="https://user-images.githubusercontent.com/75836834/117925575-51b70500-b2ac-11eb-8b1f-36d71b6de77b.png">


## Solution

1. script args in `full-install.sh` 
```
# Args
# 1) domain name you're signing | default: proxy.localhost
# 2) output parent folder for certs | default: /.light-certs/proxy.localhost/*
```
2. fixed up cfg file
3. fixed up CI pipeline


